### PR TITLE
Change to multiple "musicalPart" elements can be load.

### DIFF
--- a/libvsqx.cpp
+++ b/libvsqx.cpp
@@ -195,11 +195,13 @@ int VsqxDoc::load()
 		vsTrack->name = vsTrackElement->FirstChildElement("trackName")->GetText();
 		vsTrack->comment = vsTrackElement->FirstChildElement("comment")->GetText();
 		XMLElement *musicalPartElement = vsTrackElement->FirstChildElement("musicalPart");
-		if(musicalPartElement != NULL)//In some case, we don't have musicalPart.
+		while(musicalPartElement != NULL)//In some case, we don't have musicalPart.
 		{
 			VMusicalPart *musicalPart = new VMusicalPart;
 			vsTrack->musicalPart.push_back(musicalPart);
 			musicalPart->loadInfo(musicalPartElement);
+			
+			musicalPartElement = musicalPartElement->NextSiblingElement("musicalPart");
 		}
 
 		track.push_back(vsTrack);


### PR DESCRIPTION
@marty1885 
Changed to recursive processing so that multiple "musicalPart" elements can be load.
In past code, if more than one "musicalPart" element exists, it was not able to read after the first element.
..sorry I am Japanese and poor English skill.